### PR TITLE
[DT-039079] Box Module's "Use JSON Authentication File" setting allows non JSON type files to be uploaded

### DIFF
--- a/Decisions.Box/BoxSettings.cs
+++ b/Decisions.Box/BoxSettings.cs
@@ -342,6 +342,10 @@ public class BoxSettings : AbstractModuleSettings, IInitializable, INotifyProper
         {
             if (JsonConfig == null)
                 issues.Add(new ValidationIssue(JsonConfig, "You must provide the JSON configuration file provided in your administration console."));
+            
+            string extension = System.IO.Path.GetExtension(JsonConfig?.FileName) ?? "";
+            if (!extension.Contains("json", StringComparison.OrdinalIgnoreCase))
+                issues.Add(new ValidationIssue(this, "Unexpected file extension; file extension is not JSON"));
         }
         else if (!useDeveloperToken)
         {

--- a/Decisions.Box/BoxSettings.cs
+++ b/Decisions.Box/BoxSettings.cs
@@ -344,8 +344,8 @@ public class BoxSettings : AbstractModuleSettings, IInitializable, INotifyProper
                 issues.Add(new ValidationIssue(JsonConfig, "You must provide the JSON configuration file provided in your administration console."));
             
             string extension = System.IO.Path.GetExtension(JsonConfig?.FileName) ?? "";
-            if (!extension.Contains("json", StringComparison.OrdinalIgnoreCase))
-                issues.Add(new ValidationIssue(this, "Unexpected file extension; file extension is not JSON"));
+            if (!extension.EndsWith("json", StringComparison.OrdinalIgnoreCase))
+                issues.Add(new ValidationIssue(this, "Unexpected File Extension. The Configuration File must be a valid JSON file with a .json extension."));
         }
         else if (!useDeveloperToken)
         {

--- a/Module.Build.json
+++ b/Module.Build.json
@@ -16,7 +16,7 @@
 		"ObjectsToImport": null,
 		"MsSqlScript": null
     },
-    "Version": "8.15.0",
+    "Version": "8.17.0",
     "ImagePath": "./image.png",
     "Description": "Box.com is a cloud file storage service.  This module allows user to store files in Box.com from a Flow, or get files from Box in a Flow."
 }


### PR DESCRIPTION
Added validation for the settings dialog on JSON file configuration upload.  Before any file extension was allowed.

Happy path: case-insensitive file uploads with proper extension tested and works

New: non-json files present validation warning (see screenshot)
![DT-039079](https://github.com/Decisions-Modules/Decisions.Box/assets/110414907/974c59f0-5629-41ed-8d56-09a26eed903f)
