### PR TITLE
[DT-046006] Box Module is Missing DLL

### DIFF
--- a/Decisions.Box/Decisions.Box.csproj
+++ b/Decisions.Box/Decisions.Box.csproj
@@ -3,12 +3,12 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Box.V2" Version="5.2.2" />
-    <PackageReference Include="DecisionsSDK" Version="8.8.0" />
+    <PackageReference Include="Box.V2" Version="5.8.0" />
+    <PackageReference Include="DecisionsSDK" Version="9.15.0" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/Module.Build.json
+++ b/Module.Build.json
@@ -16,7 +16,7 @@
 		"ObjectsToImport": null,
 		"MsSqlScript": null
     },
-    "Version": "9.0.0",
+    "Version": "9.15.0",
     "ImagePath": "./image.png",
     "Description": "Box.com is a cloud file storage service.  This module allows user to store files in Box.com from a Flow, or get files from Box in a Flow."
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "9.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
As of 9.15, we have updated our BouncyCastle package which resulted in the dll changing. The Box.V2 package used by the module depends on the old BouncyCastle dll. I have updated the Box.V2 package to version that uses the new BouncyCastle dll